### PR TITLE
Add security group ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ This terraform deploys an RDS instance.
 module "rds" {
   source = "github.com/byu-oit/terraform-aws-rds?ref=v0.2.0"
 
-  identifier     = "example"
-  engine         = "mysql"
-  engine_version = "8.0"
+  source                  = "../.."
+  identifier              = "example"
+  engine                  = "mysql"
+  engine_version          = "8.0"
+  security_group_ids      = [module.acs.rds_security_group.id]
+  cloudwatch_logs_exports = ["error", "general"]
 
   db_name           = "example"
   subnet_ids        = module.acs.data_subnet_ids
@@ -42,6 +45,7 @@ module "rds" {
 | `skip_final_snapshot` | boolean | If set to true, no final snapshot of the database will be made when its deleted. | false |
 | `cloudwatch_logs_exports` | list(string) | List of log types to enable for exporting to CloudWatch logs. Each engine has different valid values | ['audit', 'error', 'general', 'slowquery'] |
 | `tags` | map(string) | A map of AWS Tags to attach to each resource created | {} |
+| `security_group_ids` | list(string) | A list of security group ids of security groups to attach to the RDS instance. This is in addition to the security group created in the module. | [] |
 
 #### master_username/master_password
 You can provide your own username and password, but please **DO NOT COMMIT** your password to source code.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This terraform deploys an RDS instance.
 module "rds" {
   source = "github.com/byu-oit/terraform-aws-rds?ref=v0.2.0"
 
-  source                  = "../.."
   identifier              = "example"
   engine                  = "mysql"
   engine_version          = "8.0"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This terraform deploys an RDS instance.
 ## Usage
 ```hcl
 module "rds" {
-  source = "github.com/byu-oit/terraform-aws-rds?ref=v0.2.0"
+  source = "github.com/byu-oit/terraform-aws-rds?ref=v0.2.1"
 
   identifier              = "example"
   engine                  = "mysql"

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -9,7 +9,7 @@ module "acs" {
 }
 
 module "rds" {
-  //  source = "github.com/byu-oit/terraform-aws-rds?ref=v0.2.0"
+  //  source = "github.com/byu-oit/terraform-aws-rds?ref=v0.2.1"
   source                  = "../.."
   identifier              = "example"
   engine                  = "mysql"

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -10,10 +10,12 @@ module "acs" {
 
 module "rds" {
   //  source = "github.com/byu-oit/terraform-aws-rds?ref=v0.2.0"
-  source         = "../.."
-  identifier     = "example"
-  engine         = "mysql"
-  engine_version = "8.0"
+  source                  = "../.."
+  identifier              = "example"
+  engine                  = "mysql"
+  engine_version          = "8.0"
+  security_group_ids      = [module.acs.rds_security_group.id]
+  cloudwatch_logs_exports = ["error", "general"]
 
   db_name           = "example"
   subnet_ids        = module.acs.data_subnet_ids

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_db_instance" "database" {
   enabled_cloudwatch_logs_exports = var.cloudwatch_logs_exports
 
   db_subnet_group_name   = var.subnet_group_name
-  vpc_security_group_ids = [aws_security_group.db_security_group.id]
+  vpc_security_group_ids = concat(var.security_group_ids, [aws_security_group.db_security_group.id])
 
   skip_final_snapshot       = var.skip_final_snapshot
   final_snapshot_identifier = "${var.identifier}-final-snapshot"

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "tags" {
   description = "A map of AWS Tags to attach to each resource created"
   default     = {}
 }
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "List of additional security group ids to add to the RDS instance"
+  default     = []
+}


### PR DESCRIPTION
I tested this in the mendix-dev account, and seems to work fine. It adds security groups on top of the security group created in the module. This is especially useful when trying to add the RDS security group defined in ACS.