### PR TITLE
Generate random master username

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This terraform deploys an RDS instance.
 ## Usage
 ```hcl
 module "rds" {
-  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.2.0"
+  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.2.1"
 
   identifier              = "example"
   engine                  = "mysql"

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -8,7 +8,7 @@ module "acs" {
 }
 
 module "rds" {
-  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.2.0"
+  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.2.1"
   //  source                  = "../.."
   identifier              = "example"
   engine                  = "mysql"

--- a/main.tf
+++ b/main.tf
@@ -17,11 +17,19 @@ resource "random_password" "default" {
     recreate_password = false
   }
 }
+resource "random_string" "default" {
+  count   = var.master_username == null ? 1 : 0
+  length  = 16
+  special = false
+  keepers = {
+    recreate_username = false
+  }
+}
 resource "aws_ssm_parameter" "master_username" {
   name        = "${local.ssm_prefix}/master_username"
   description = "${var.identifier} Database master username"
   type        = "String"
-  value       = var.master_username != null ? var.master_username : "${var.identifier}_root"
+  value       = var.master_username != null ? var.master_username : random_string.default[0].result
   tags        = var.tags
 }
 resource "aws_ssm_parameter" "master_password" {


### PR DESCRIPTION
The master username currently depends on the database identifier which, in many cases, is longer than 16 characters. Usernames that are longer than 16 characters cause deployment failures for those using MySQL or MariaDB according to the AWS documentation here: https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html. To prevent these automatic failures, we can generate a random string for the username that is 16 characters in length. All other database flavors currently offered by AWS support 16 letter usernames.