### PR TITLE
Only user letters for username

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This terraform deploys an RDS instance.
 ## Usage
 ```hcl
 module "rds" {
-  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.3.0"
+  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.3.1"
 
   identifier              = "example"
   engine                  = "mysql"

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -8,7 +8,7 @@ module "acs" {
 }
 
 module "rds" {
-  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.3.0"
+  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.3.1"
   //  source                  = "../.."
   identifier              = "example"
   engine                  = "mysql"

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "random_string" "default" {
   count   = var.master_username == null ? 1 : 0
   length  = 16
   special = false
+  number  = false
   keepers = {
     recreate_username = false
   }


### PR DESCRIPTION
According to the RDS documentation, for the PostgreSQL master usersname, the "First character must be a letter." There is a 16% change of that not happening...and it happened to me. This change will keep numbers out of the master username to be sure that doesn't happen.
