### PR TITLE
Change default rds instance to t3 family

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This terraform deploys an RDS instance.
 ## Usage
 ```hcl
 module "rds" {
-  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.3.1"
+  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.3.2"
 
   identifier              = "example"
   engine                  = "mysql"

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -8,7 +8,7 @@ module "acs" {
 }
 
 module "rds" {
-  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.3.1"
+  source = "github.com/byu-oit/terraform-aws-rds?ref=v2.3.2"
   //  source                  = "../.."
   identifier              = "example"
   engine                  = "mysql"

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "identifier" {
 variable "instance_class" {
   type        = string
   description = "The instance type to use for the database"
-  default     = "db.t2.small"
+  default     = "db.t3.small"
 }
 variable "engine" {
   type        = string


### PR DESCRIPTION
Because t3 instances are cheaper and are sometimes more performant, the BYU cloud office is considering preventing t2 hardware from being launched to encourage the use of t3 instances. Regardless of the decision the cloud office makes, t3 family instances seem like a better default for cost and performance reasons.