### PR TITLE
Switch default `instance_class` from `db.t3.small` to `db.t4g.small`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "identifier" {
 variable "instance_class" {
   type        = string
   description = "The instance type to use for the database"
-  default     = "db.t3.small"
+  default     = "db.t4g.small"
 }
 variable "engine" {
   type        = string


### PR DESCRIPTION
I see we're already defaulting to burstable instances (`t`-series). The `t4g.small` is essentially a strict improvement over `t3.small`. It's now using Graviton processors, but that shouldn't affect anything we're doing in RDS.
![image](https://user-images.githubusercontent.com/7625337/227013362-37814162-e53e-49b1-898b-ccc937e8246b.png)
